### PR TITLE
Ignore some special characters from the very end of URL

### DIFF
--- a/Extension/UrlAutoConverterTwigExtension.php
+++ b/Extension/UrlAutoConverterTwigExtension.php
@@ -69,6 +69,9 @@ class UrlAutoConverterTwigExtension extends \Twig_Extension
 
         $style = ($this->debugMode) ? ' style="color:#00ff00"' : '';
 
+        // ignore tailing special characters
+        $urlWithPrefix = preg_replace("/(\.|\,|\?)$/", "", $urlWithPrefix);
+        
         return '<a href="'.$urlWithPrefix.'" class="'.$this->linkClass.'" target="'.$this->target.'"'.$style.'>'.$url.'</a>';
     }
 }

--- a/Tests/Extension/UrlAutoConverterTwigExtensionTest.php
+++ b/Tests/Extension/UrlAutoConverterTwigExtensionTest.php
@@ -100,7 +100,19 @@ class UrlAutoConverterTwigExtensionTest extends \PHPUnit_Framework_TestCase
             array(
                 'Lorem ipsum t.fff dolor sit amet, consectetuer.',
                 'Lorem ipsum t.fff dolor sit amet, consectetuer.'
-            )
+            ),
+            array(
+                'Lorem ipsum dolor sit amet, <a href="http://&&http://re.name" class="" target="">&&http://re.name</a>. Period!',
+                'Lorem ipsum dolor sit amet, &&http://re.name. Period!'
+            ),
+            array(
+                'Lorem ipsum dolor sit amet, <a href="http://&&http://re.name" class="" target="">&&http://re.name</a>, really?',
+                'Lorem ipsum dolor sit amet, &&http://re.name, really?'
+            ),
+            array(
+                'Lorem ipsum dolor sit amet, <a href="http://&&http://re.name" class="" target="">&&http://re.name</a>?',
+                'Lorem ipsum dolor sit amet, &&http://re.name?'
+            ),
         );
     }
 


### PR DESCRIPTION
Ignore period, comma and question mark from the very ending of the URL. Allows people to write:

"Check out my website at www.arturgajewski.com/piano. It is a piano learning ebook I wrote."

or

"Want me to visit www.github.com? Really?"

or

"My photography site is at www.arturgajewski.com, but it only contains child portraits."
