### PR TITLE
Making Percent-encoding supportable

### DIFF
--- a/Extension/UrlAutoConverterTwigExtension.php
+++ b/Extension/UrlAutoConverterTwigExtension.php
@@ -61,7 +61,7 @@ class UrlAutoConverterTwigExtension extends \Twig_Extension
      */
     public function autoConvertUrls($string)
     {
-        $pattern = '/(href="|src=")?([-a-zA-Zа-яёА-ЯЁ0-9@:%_\+.~#?&\/\/=]{2,256}\.[a-zа-яё]{2,4}\b(\/?[-\p{L}0-9@:%_\+.~#?&\/\/=\(\),]*)?)/u';
+        $pattern = '/(href="|src=")?([-a-zA-Zа-яёА-ЯЁ0-9@:%_\+.~#?&\*\/\/=]{2,256}\.[a-zа-яё]{2,4}\b(\/?[-\p{L}0-9@:%_\+.~#?&\*\/\/=\(\),;]*)?)/u';
         $stringFiltered = preg_replace_callback($pattern, array($this, 'callbackReplace'), $string);
 
         return $stringFiltered;


### PR DESCRIPTION
some of percent encoding chars were skipped. Like * or ;.