### PR TITLE
Fix homepage link

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         },
         {
             "name": "Community contributions",
-            "homepage": "https://github.com/liip/LiipThemeBundle/contributors"
+            "homepage": "https://github.com/liip/LiipUrlAutoConverterBundle/contributors"
         }
     ],
     "require": {


### PR DESCRIPTION
Apparently, this was copy-pasted from another `composer.json` file ;-).